### PR TITLE
Add "UTF8BOM" and "UTF8NoBOM" to the acceptable values for Encoding parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coverage - Fixes [Issue #50](https://github.com/dsccommunity/FileContentDsc/issues/50).
 - Automatically publish documentation to GitHub Wiki - Fixes [Issue #51](https://github.com/dsccommunity/FileContentDsc/issues/51).
 - Renamed `master` branch to `main` - Fixes [Issue #53](https://github.com/dsccommunity/FileContentDsc/issues/53).
+- Added `UTF8BOM` and `UTF8NoBOM` to the acceptable values for Encoding parameter to the KeyValuePairFile and ReplaceText - Fixes [Issue #56](https://github.com/dsccommunity/FileContentDsc/issues/56).
 
 ## [1.3.0.151] - 2019-07-20
 

--- a/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.psm1
+++ b/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.psm1
@@ -180,7 +180,7 @@ function Set-TargetResource
         $IgnoreValueCase = $false,
 
         [Parameter()]
-        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF32')]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )
@@ -281,7 +281,7 @@ function Set-TargetResource
         $fileProperties.Add('Encoding', $Encoding)
     }
 
-    Set-Content @fileProperties
+    Set-TextContent @fileProperties
 }
 
 <#
@@ -362,7 +362,7 @@ function Test-TargetResource
         $IgnoreValueCase = $false,
 
         [Parameter()]
-        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF32')]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )
@@ -543,7 +543,7 @@ function Assert-ParametersValid
         $IgnoreValueCase = $false,
 
         [Parameter()]
-        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF32')]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )

--- a/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.psm1
+++ b/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.psm1
@@ -47,8 +47,19 @@ function Get-TargetResource
 
     if (Test-Path -Path $Path)
     {
-        $fileContent = Get-Content -Path $Path -Raw
-        $fileEncoding = Get-FileEncoding -Path $Path
+        $fileEncoding = Get-FileEncoding $Path -ErrorAction SilentlyContinue
+        if ($null -eq $fileEncoding)
+        {
+            $fileContent = Get-Content -Path $Path -Raw
+        }
+        elseif ($fileEncoding -like 'UTF8*')
+        {
+            $fileContent = Get-Content -Path $Path -Raw -Encoding 'UTF8'
+        }
+        else
+        {
+            $fileContent = Get-Content -Path $Path -Raw -Encoding $fileEncoding
+        }
 
         if ($null -ne $fileContent)
         {
@@ -187,8 +198,19 @@ function Set-TargetResource
 
     Assert-ParametersValid @PSBoundParameters
 
-    $fileContent = Get-Content -Path $Path -Raw -ErrorAction SilentlyContinue
-    $fileEncoding = Get-FileEncoding -Path $Path -ErrorAction SilentlyContinue
+    $fileEncoding = Get-FileEncoding $Path -ErrorAction SilentlyContinue
+    if ($null -eq $fileEncoding)
+    {
+        $fileContent = Get-Content -Path $Path -Raw -ErrorAction SilentlyContinue
+    }
+    elseif ($fileEncoding -like 'UTF8*')
+    {
+        $fileContent = Get-Content -Path $Path -Raw -Encoding 'UTF8' -ErrorAction SilentlyContinue
+    }
+    else
+    {
+        $fileContent = Get-Content -Path $Path -Raw -Encoding $fileEncoding -ErrorAction SilentlyContinue
+    }
 
     $fileProperties = @{
         Path      = $Path
@@ -248,10 +270,13 @@ function Set-TargetResource
         {
             if ($results.Count -eq 0)
             {
-                if ($PSBoundParameters.ContainsKey('Encoding') -and ($Encoding -eq $fileEncoding))
+                if ($PSBoundParameters.ContainsKey('Encoding') -and `
+                    (($Encoding -eq $fileEncoding) -or `
+                        ($Encoding -eq 'UTF8' -and $fileEncoding -like 'UTF8*') -or `
+                        ($Encoding -eq 'UTF8NoBOM' -and $fileEncoding -eq 'ASCII')))
                 {
-                        # The Key does not exists and should not, and encoding is in the desired state, so don't do anything
-                        return
+                    # The Key does not exists and should not, and encoding is in the desired state, so don't do anything
+                    return
                 }
                 else
                 {
@@ -380,7 +405,19 @@ function Test-TargetResource
         return ($Ensure -eq 'Absent')
     }
 
-    $fileContent = Get-Content -Path $Path -Raw
+    $fileEncoding = Get-FileEncoding $Path -ErrorAction SilentlyContinue
+    if ($null -eq $fileEncoding)
+    {
+        $fileContent = Get-Content -Path $Path -Raw
+    }
+    elseif ($fileEncoding -like 'UTF8*')
+    {
+        $fileContent = Get-Content -Path $Path -Raw -Encoding 'UTF8'
+    }
+    else
+    {
+        $fileContent = Get-Content -Path $Path -Raw -Encoding $fileEncoding
+    }
 
     if ($null -eq $fileContent)
     {
@@ -390,7 +427,6 @@ function Test-TargetResource
     }
 
     $desiredConfigurationMatch = $true
-    $fileEncoding = Get-FileEncoding -Path $Path
     $regExOptions = [System.Text.RegularExpressions.RegexOptions]::Multiline
 
     Write-Verbose -Message ($script:localizedData.SearchForKeyMessage -f $Path, $Name)
@@ -456,10 +492,23 @@ function Test-TargetResource
 
     if ($PSBoundParameters.ContainsKey('Encoding') -and ($Encoding -ne $fileEncoding))
     {
-        # File encoding is not in desired state
-        Write-Verbose -Message ($script:localizedData.FileEncodingNotInDesiredState -f $fileEncoding, $Encoding)
+        if ($Encoding -eq 'UTF8' -and $fileEncoding -like 'UTF8*')
+        {
+            #If the Encoding specified as UTF8, Either UTF8NoBOM or UTF8BOM is acceptable
+            $desiredConfigurationMatch = $true
+        }
+        elseif ($Encoding -eq 'UTF8NoBOM' -and $fileEncoding -eq 'ASCII')
+        {
+            #If the Encoding specified as UTF8NoBOM, Either UTF8NoBOM or ASCII is acceptable
+            $desiredConfigurationMatch = $true
+        }
+        else
+        {
+            # File encoding is not in desired state
+            Write-Verbose -Message ($script:localizedData.FileEncodingNotInDesiredState -f $fileEncoding, $Encoding)
 
-        $desiredConfigurationMatch = $false
+            $desiredConfigurationMatch = $false
+        }
     }
 
     return $desiredConfigurationMatch

--- a/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.schema.mof
+++ b/source/DSCResources/DSC_KeyValuePairFile/DSC_KeyValuePairFile.schema.mof
@@ -9,5 +9,5 @@ class DSC_KeyValuePairFile : OMI_BaseResource
   [write, Description("The secret text to replace the value with in the identified key. Only used when Type is set to 'Secret'."),EmbeddedInstance("MSFT_Credential")] String Secret;
   [Write, Description("Ignore the case of the name of the key. Defaults to $False.")] Boolean IgnoreNameCase;
   [Write, Description("Ignore the case of any text or secret when determining if it they need to be updated. Defaults to $False.")] Boolean IgnoreValueCase;
-  [Write, Description("Specifies the file encoding. Defaults to ASCII"),ValueMap{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32"},Values{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32"}] String Encoding;
+  [Write, Description("Specifies the file encoding. Defaults to ASCII"),ValueMap{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF8BOM", "UTF8NoBOM", "UTF32"},Values{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF8BOM", "UTF8NoBOM", "UTF32"}] String Encoding;
 };

--- a/source/DSCResources/DSC_ReplaceText/DSC_ReplaceText.psm1
+++ b/source/DSCResources/DSC_ReplaceText/DSC_ReplaceText.psm1
@@ -136,7 +136,7 @@ function Set-TargetResource
         $AllowAppend = $false,
 
         [Parameter()]
-        [ValidateSet("ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32")]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )
@@ -194,7 +194,7 @@ function Set-TargetResource
 
     $fileProperties.Add('Value', $fileContent)
 
-    Set-Content @fileProperties
+    Set-TextContent @fileProperties
 }
 
 <#
@@ -259,7 +259,7 @@ function Test-TargetResource
         $AllowAppend = $false,
 
         [Parameter()]
-        [ValidateSet("ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32")]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )
@@ -401,7 +401,7 @@ function Assert-ParametersValid
         $AllowAppend = $false,
 
         [Parameter()]
-        [ValidateSet("ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32")]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'BigEndianUTF32', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [System.String]
         $Encoding
     )

--- a/source/DSCResources/DSC_ReplaceText/DSC_ReplaceText.schema.mof
+++ b/source/DSCResources/DSC_ReplaceText/DSC_ReplaceText.schema.mof
@@ -7,5 +7,5 @@ class DSC_ReplaceText : OMI_BaseResource
   [Write, Description("The text to replace the text identified by the RegEx. Only used when Type is set to 'Text'.")] String Text;
   [Write, Description("The secret text to replace the text identified by the RegEx. Only used when Type is set to 'Secret'."),EmbeddedInstance("MSFT_Credential")] String Secret;
   [Write, Description("Specifies to append text to the file being modified. Adds the ability to add a configuration entry.")] Boolean AllowAppend;
-  [Write, Description("Specifies the file encoding. Defaults to ASCII"),ValueMap{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32"},Values{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF32"}] String Encoding;
+  [Write, Description("Specifies the file encoding. Defaults to ASCII"),ValueMap{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF8BOM", "UTF8NoBOM", "UTF32"},Values{"ASCII", "BigEndianUnicode", "BigEndianUTF32", "UTF8", "UTF8BOM", "UTF8NoBOM", "UTF32"}] String Encoding;
 };

--- a/source/Modules/FileContentDsc.Common/FileContentDsc.Common.psm1
+++ b/source/Modules/FileContentDsc.Common/FileContentDsc.Common.psm1
@@ -208,10 +208,10 @@ function Get-FileEncoding
         This is an enhanced version of the Set-Content that allows UTF8BOM and UTF8NoBOM encodings in PS v5.1 and earlier.
 
     .EXAMPLE
-        Set-ContentEnhanced -Path 'C:\hello.txt' -Value 'Hello World' -Encoding UTF8NoBOM
+        Set-TextContent -Path 'C:\hello.txt' -Value 'Hello World' -Encoding UTF8NoBOM
         This command creates a text file encoded in UTF-8 without BOM (Byte Order Mark).
 #>
-function Set-ContentEnhanced
+function Set-TextContent
 {
     [CmdletBinding()]
     [OutputType([void])]
@@ -288,5 +288,5 @@ Export-ModuleMember -Function @(
     'Set-IniSettingFileValue',
     'Get-IniSettingFileValue',
     'Get-FileEncoding'
-    'Set-ContentEnhanced'
+    'Set-TextContent'
 )

--- a/source/Modules/FileContentDsc.Common/FileContentDsc.Common.psm1
+++ b/source/Modules/FileContentDsc.Common/FileContentDsc.Common.psm1
@@ -222,7 +222,7 @@ function Set-TextContent
         $Path,
 
         [Parameter(Position = 1, Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
-        [System.String]
+        [Object[]]
         $Value,
 
         [Parameter()]

--- a/tests/TestHelpers/CommonTestHelper.psm1
+++ b/tests/TestHelpers/CommonTestHelper.psm1
@@ -109,11 +109,20 @@ function Get-FileEncoding
         $Path
     )
 
-    [System.Byte[]] $byte = Get-Content -Encoding byte -ReadCount 4 -TotalCount 4 -Path $Path
+    # The parameter for reading a file as a byte stream are different between PSv6 and later and earlier.
+    $ByteParam = if ($PSVersionTable.PSVersion.Major -ge 6)
+    {
+        @{AsByteStream = $true }
+    }
+    else
+    {
+        @{Encoding = 'byte' }
+    }
 
+    [System.Byte[]] $byte = Get-Content @ByteParam -ReadCount 4 -TotalCount 4 -Path $Path
     if ($byte[0] -eq 0xef -and $byte[1] -eq 0xbb -and $byte[2] -eq 0xbf)
     {
-        return 'UTF8'
+        return 'UTF8BOM'
     }
     elseif ($byte[0] -eq 0xff -and $byte[1] -eq 0xfe)
     {
@@ -129,7 +138,18 @@ function Get-FileEncoding
     }
     else
     {
-        return 'ASCII'
+        # Read all bytes for guessing encoding.
+        [System.Byte[]] $byte = Get-Content @ByteParam -ReadCount 0 -Path $Path
+
+        # If a text file includes code after 0x7f, which should not exist in ASCII, it is determined as UTF8NoBOM.
+        if ($byte -gt 0x7f)
+        {
+            return 'UTF8NoBOM'
+        }
+        else
+        {
+            return 'ASCII'
+        }
     }
 }
 

--- a/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
+++ b/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
@@ -320,7 +320,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -347,7 +347,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -363,7 +363,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -390,7 +390,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -407,7 +407,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -434,7 +434,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -451,7 +451,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -479,7 +479,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -496,7 +496,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content `
+                Mock -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentAdded)
@@ -527,7 +527,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -544,7 +544,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -572,7 +572,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -589,7 +589,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -616,7 +616,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -Exactly -Times 0
                 }
@@ -629,7 +629,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-Content
+                Mock -CommandName Set-ContentEnhanced
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -656,7 +656,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-Content `
+                    Assert-MockCalled -CommandName Set-ContentEnhanced `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `

--- a/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
+++ b/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
@@ -127,9 +127,9 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Get-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -172,9 +172,9 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Get-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -222,9 +222,9 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Get-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -272,9 +272,9 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Get-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -324,11 +324,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -350,9 +350,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq "$script:testName=$script:testText")
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq "$script:testName=$script:testText")
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -367,11 +367,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -393,9 +393,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq "$script:testName=$script:testText")
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq "$script:testName=$script:testText")
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -411,11 +411,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -437,9 +437,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq $script:testFileExpectedTextContent)
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq $script:testFileExpectedTextContent)
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -455,12 +455,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Type 'Secret' `
-                        -Secret $script:testSecretCredential `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Type 'Secret' `
+                            -Secret $script:testSecretCredential `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -482,9 +482,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq $script:testFileExpectedSecretContent)
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq $script:testFileExpectedSecretContent)
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -498,17 +498,17 @@ $($script:testAddedName)=$($script:testText)
 
                 Mock -CommandName Set-TextContent `
                     -ParameterFilter {
-                        ($path -eq $script:testTextFile) -and `
-                        ($value -eq $script:testFileExpectedTextContentAdded)
-                    }
+                    ($path -eq $script:testTextFile) -and `
+                    ($value -eq $script:testFileExpectedTextContentAdded)
+                }
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testAddedName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testAddedName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -530,9 +530,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq $script:testFileExpectedTextContentAdded)
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq $script:testFileExpectedTextContentAdded)
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -548,12 +548,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -IgnoreNameCase:$true `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -IgnoreNameCase:$true `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -575,9 +575,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq $script:testFileExpectedTextContentUpper)
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq $script:testFileExpectedTextContentUpper)
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -593,11 +593,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Encoding $script:fileEncodingParameters.Encoding `
-                        -Ensure 'Absent' `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Encoding $script:fileEncodingParameters.Encoding `
+                            -Ensure 'Absent' `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -633,11 +633,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Absent' `
-                        -IgnoreNameCase:$true `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Absent' `
+                            -IgnoreNameCase:$true `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -659,9 +659,9 @@ $($script:testAddedName)=$($script:testText)
                     Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
-                            ($path -eq $script:testTextFile) -and `
-                            ($value -eq $script:testFileExpectedAbsentContent)
-                        } `
+                        ($path -eq $script:testTextFile) -and `
+                        ($value -eq $script:testFileExpectedAbsentContent)
+                    } `
                         -Exactly -Times 1
                 }
             }
@@ -681,11 +681,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -717,11 +717,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Absent' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Absent' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -753,11 +753,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -777,7 +777,7 @@ $($script:testAddedName)=$($script:testText)
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
                         -Scope Context `
-                        -Exactly -Times 0
+                        -Exactly -Times 1
                 }
             }
 
@@ -790,11 +790,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Absent' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Absent' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -814,7 +814,7 @@ $($script:testAddedName)=$($script:testText)
 
                     Assert-MockCalled -CommandName Get-FileEncoding `
                         -Scope Context `
-                        -Exactly -Times 0
+                        -Exactly -Times 1
                 }
             }
 
@@ -830,11 +830,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -871,11 +871,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Absent' `
-                        -Encoding $script:fileEncodingParameters.Encoding `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Absent' `
+                            -Encoding $script:fileEncodingParameters.Encoding `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -912,11 +912,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Encoding $script:fileEncodingParameters.Encoding `
-                        -Ensure 'Absent' `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Encoding $script:fileEncodingParameters.Encoding `
+                            -Ensure 'Absent' `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -953,11 +953,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -994,12 +994,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -Encoding $script:fileEncodingParameters.Encoding `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -Encoding $script:fileEncodingParameters.Encoding `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1036,12 +1036,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Type 'Secret' `
-                        -Secret $script:testSecretCredential `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Type 'Secret' `
+                            -Secret $script:testSecretCredential `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1078,12 +1078,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Type 'Secret' `
-                        -Secret $script:testSecretCredential `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Type 'Secret' `
+                            -Secret $script:testSecretCredential `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1120,13 +1120,13 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Type 'Secret' `
-                        -Secret $script:testSecretCredential `
-                        -Encoding $script:fileEncodingParameters.Encoding `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Type 'Secret' `
+                            -Secret $script:testSecretCredential `
+                            -Encoding $script:fileEncodingParameters.Encoding `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1163,12 +1163,12 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName.ToUpper() `
-                        -Ensure 'Present' `
-                        -Text $script:testText `
-                        -IgnoreNameCase:$true `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName.ToUpper() `
+                            -Ensure 'Present' `
+                            -Text $script:testText `
+                            -IgnoreNameCase:$true `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1205,11 +1205,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Present' `
-                        -Text $script:testText.ToUpper() `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Present' `
+                            -Text $script:testText.ToUpper() `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 
@@ -1288,11 +1288,11 @@ $($script:testAddedName)=$($script:testText)
 
                 It 'Should not throw an exception' {
                     { $script:result = Test-TargetResource `
-                        -Path $script:testTextFile `
-                        -Name $script:testName `
-                        -Ensure 'Absent' `
-                        -Text $script:testText `
-                        -Verbose
+                            -Path $script:testTextFile `
+                            -Name $script:testName `
+                            -Ensure 'Absent' `
+                            -Text $script:testText `
+                            -Verbose
                     } | Should -Not -Throw
                 }
 

--- a/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
+++ b/tests/Unit/DSC_KeyValuePairFile.Tests.ps1
@@ -320,7 +320,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -347,7 +347,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -363,7 +363,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -390,7 +390,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -407,7 +407,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -434,7 +434,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -451,7 +451,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -479,7 +479,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -496,7 +496,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced `
+                Mock -CommandName Set-TextContent `
                     -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentAdded)
@@ -527,7 +527,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -544,7 +544,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -572,7 +572,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `
@@ -589,7 +589,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -616,7 +616,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -Exactly -Times 0
                 }
@@ -629,7 +629,7 @@ $($script:testAddedName)=$($script:testText)
                 Mock -CommandName Get-FileEncoding `
                     -MockWith { $script:testCompliantEncoding.Encoding }
 
-                Mock -CommandName Set-ContentEnhanced
+                Mock -CommandName Set-TextContent
 
                 It 'Should not throw an exception' {
                     { Set-TargetResource `
@@ -656,7 +656,7 @@ $($script:testAddedName)=$($script:testText)
                         -ParameterFilter { $path -eq $script:testTextFile } `
                         -Exactly -Times 1
 
-                    Assert-MockCalled -CommandName Set-ContentEnhanced `
+                    Assert-MockCalled -CommandName Set-TextContent `
                         -Scope Context `
                         -ParameterFilter {
                             ($path -eq $script:testTextFile) -and `

--- a/tests/Unit/DSC_ReplaceText.Tests.ps1
+++ b/tests/Unit/DSC_ReplaceText.Tests.ps1
@@ -333,7 +333,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Content `
+                    -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedTextContent)
@@ -359,7 +359,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-Content `
+                        -CommandName Set-ContentEnhanced `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContent)
@@ -388,7 +388,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Content `
+                    -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedTextContentNewKey)
@@ -415,7 +415,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-Content `
+                        -CommandName Set-ContentEnhanced `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentNewKey)
@@ -443,7 +443,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Content `
+                    -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileContent)
@@ -470,7 +470,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-Content `
+                        -CommandName Set-ContentEnhanced `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileContent)
@@ -499,7 +499,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Content `
+                    -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedSecretContent)
@@ -526,7 +526,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-Content `
+                        -CommandName Set-ContentEnhanced `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedSecretContent)
@@ -555,7 +555,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-Content `
+                    -CommandName Set-ContentEnhanced `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testTextReplace)
@@ -581,7 +581,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-Content `
+                        -CommandName Set-ContentEnhanced `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testTextReplace)

--- a/tests/Unit/DSC_ReplaceText.Tests.ps1
+++ b/tests/Unit/DSC_ReplaceText.Tests.ps1
@@ -333,7 +333,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-ContentEnhanced `
+                    -CommandName Set-TextContent `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedTextContent)
@@ -359,7 +359,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-ContentEnhanced `
+                        -CommandName Set-TextContent `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContent)
@@ -388,7 +388,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-ContentEnhanced `
+                    -CommandName Set-TextContent `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedTextContentNewKey)
@@ -415,7 +415,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-ContentEnhanced `
+                        -CommandName Set-TextContent `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedTextContentNewKey)
@@ -443,7 +443,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-ContentEnhanced `
+                    -CommandName Set-TextContent `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileContent)
@@ -470,7 +470,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-ContentEnhanced `
+                        -CommandName Set-TextContent `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileContent)
@@ -499,7 +499,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-ContentEnhanced `
+                    -CommandName Set-TextContent `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testFileExpectedSecretContent)
@@ -526,7 +526,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-ContentEnhanced `
+                        -CommandName Set-TextContent `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testFileExpectedSecretContent)
@@ -555,7 +555,7 @@ Setting3.Test=Value4
                     -Verifiable
 
                 Mock `
-                    -CommandName Set-ContentEnhanced `
+                    -CommandName Set-TextContent `
                     -ParameterFilter {
                     ($path -eq $script:testTextFile) -and `
                     ($value -eq $script:testTextReplace)
@@ -581,7 +581,7 @@ Setting3.Test=Value4
                         -Exactly 1
 
                     Assert-MockCalled `
-                        -CommandName Set-ContentEnhanced `
+                        -CommandName Set-TextContent `
                         -ParameterFilter {
                         ($path -eq $script:testTextFile) -and `
                         ($value -eq $script:testTextReplace)

--- a/tests/Unit/FileContentDsc.Common.tests.ps1
+++ b/tests/Unit/FileContentDsc.Common.tests.ps1
@@ -91,4 +91,84 @@ InModuleScope $script:subModuleName {
             }
         }
     }
+
+    Describe 'FileContentDsc.Common\Set-TextContent' {
+        $testTextFile = "TestDrive:\TestFile.txt"
+        $value = [string][char]0x0398 #Non-Ascii character
+        $testCases = @(
+            @{
+                encoding             = 'ASCII'
+                expectedValueInBytes = [byte[]](63)
+            },
+            @{
+                encoding             = 'BigEndianUnicode'
+                expectedValueInBytes = [byte[]](254, 255, 3, 152)
+            },
+            @{
+                encoding             = 'BigEndianUTF32'
+                expectedValueInBytes = [byte[]](0, 0, 254, 255, 0, 0, 3, 152)
+            },
+            @{
+                encoding = 'UTF8'
+            },
+            @{
+                encoding             = 'UTF8BOM'
+                expectedValueInBytes = [byte[]](239, 187, 191, 206, 152)
+            },
+            @{
+                encoding             = 'UTF8NoBOM'
+                expectedValueInBytes = [byte[]](206, 152)
+            },
+            @{
+                encoding             = 'UTF32'
+                expectedValueInBytes = [byte[]](255, 254, 0, 0, 152, 3, 0, 0)
+            }
+        )
+
+        Context 'When save text file' {
+            It "Should create a text file with '<Encoding>' encoding" -TestCases $testCases {
+                param
+                (
+                    [Parameter()]
+                    [System.String]
+                    $Encoding,
+
+                    [Parameter()]
+                    [byte[]]
+                    $ExpectedValueInBytes
+                )
+
+                Set-TextContent -Path $testTextFile -Value $value -Encoding $Encoding -Force -NoNewLine
+
+                # PowerShell 6 or later
+                if ($PSVersionTable.PSVersion.Major -ge 6)
+                {
+                    $result = Get-Content -Path $testTextFile -Raw -AsByteStream
+                    if ($Encoding -eq 'UTF8')
+                    {
+                        # In the PowerShell v6+, UTF8 has not BOM by default.
+                        $result | Should -Be ([byte[]](206, 152))
+                    }
+                    else
+                    {
+                        $result | Should -Be $ExpectedValueInBytes
+                    }
+                }
+                # PowerShell 5.1 or earlier
+                else
+                {
+                    $result = Get-Content -Path $testTextFile -Raw -Encoding Byte
+                    if ($Encoding -eq 'UTF8')
+                    {
+                        # In the PowerShell v5, UTF8 has BOM by default.
+                        $result | Should -Be ([byte[]](239, 187, 191, 206, 152))
+                    }
+                    else
+                    {
+                        $result | Should -Be $ExpectedValueInBytes
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Added `UTF8BOM` and `UTF8NoBOM` to the acceptable values for Encoding parameter to the KeyValuePairFile and ReplaceText.  

#### This Pull Request (PR) fixes the following issues
- Fixes #56


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
